### PR TITLE
fix: Re-add fail_span helper

### DIFF
--- a/util/tracing/src/error.rs
+++ b/util/tracing/src/error.rs
@@ -1,3 +1,23 @@
+use opentracingrust::Log;
+use opentracingrust::Span;
+
+/// Re-implement `FailSpan` for `Fail` errors :-(
+pub fn fail_span<'a, F, S>(error: F, span: S) -> F
+where
+    F: failure::Fail,
+    S: Into<Option<&'a mut Span>>,
+{
+    if let Some(span) = span.into() {
+        span.tag("error", true);
+        span.log(
+            Log::new()
+                .log("event", "error")
+                .log("message", error.to_string()),
+        );
+    }
+    error
+}
+
 /// Error information returned by functions in case of errors.
 #[derive(thiserror::Error, Debug)]
 pub enum Error {

--- a/util/tracing/src/lib.rs
+++ b/util/tracing/src/lib.rs
@@ -13,6 +13,7 @@ mod config;
 mod error;
 
 pub use self::config::Config;
+pub use self::error::fail_span;
 pub use self::error::Error;
 
 /// Wrapper for easier optional `Tracer`s.


### PR DESCRIPTION
This is currently needed in too many places.
Removal will happen as part of the (eventual) move to OpenTelemetry.